### PR TITLE
Gke remove default np

### DIFF
--- a/modules/private-cluster/cluster.tf
+++ b/modules/private-cluster/cluster.tf
@@ -142,49 +142,6 @@ resource "google_container_cluster" "primary" {
   ## From Terraform docs: Must be set if node_pool is not set. 
   initial_node_count = var.initial_node_count
   remove_default_node_pool = var.remove_default_node_pool
-  # node_pool {
-  #   name               = "default-pool"
-  #   initial_node_count = var.initial_node_count
-
-  #   node_config {
-  #     image_type       = lookup(var.node_pools[0], "image_type", "COS_CONTAINERD")
-  #     machine_type     = lookup(var.node_pools[0], "machine_type", "e2-medium")
-  #     min_cpu_platform = lookup(var.node_pools[0], "min_cpu_platform", "")
-  #     disk_size_gb    = lookup(var.node_pools[0], "disk_size_gb", 30)
-  #     disk_type       = lookup(var.node_pools[0], "disk_type", "pd-balanced")
-  #     dynamic "gcfs_config" {
-  #       for_each = lookup(var.node_pools[0], "enable_gcfs", false) ? [true] : []
-  #       content {
-  #         enabled = gcfs_config.value
-  #       }
-  #     }
-
-  #     service_account = lookup(var.node_pools[0], "service_account", local.service_account)
-
-  #     tags = concat(
-  #       lookup(local.node_pools_tags, "default_values", [true, true])[0] ? [local.cluster_network_tag] : [],
-  #       lookup(local.node_pools_tags, "default_values", [true, true])[1] ? ["${local.cluster_network_tag}-default-pool"] : [],
-  #       lookup(local.node_pools_tags, "all", []),
-  #       lookup(local.node_pools_tags, var.node_pools[0].name, []),
-  #     )
-
-  #     dynamic "workload_metadata_config" {
-  #       for_each = local.cluster_node_metadata_config
-
-  #       content {
-  #         mode = workload_metadata_config.value.mode
-  #       }
-  #     }
-
-  #     metadata = local.node_pools_metadata["all"]
-
-
-  #     shielded_instance_config {
-  #       enable_secure_boot          = lookup(var.node_pools[0], "enable_secure_boot", false)
-  #       enable_integrity_monitoring = lookup(var.node_pools[0], "enable_integrity_monitoring", true)
-  #     }
-  #   }
-  # }
 
   dynamic "resource_usage_export_config" {
     for_each = var.resource_usage_export_dataset_id != "" ? [{

--- a/modules/private-cluster/variables.tf
+++ b/modules/private-cluster/variables.tf
@@ -129,11 +129,7 @@ variable "node_pools" {
   type        = list(map(string))
   description = "List of maps containing node pools"
 
-  default = [
-    {
-      name = "default-node-pool"
-    },
-  ]
+  default = []
 }
 
 variable "node_pools_labels" {
@@ -143,7 +139,6 @@ variable "node_pools_labels" {
   # Default is being set in variables_defaults.tf
   default = {
     all               = {}
-    default-node-pool = {}
   }
 }
 
@@ -154,7 +149,6 @@ variable "node_pools_metadata" {
   # Default is being set in variables_defaults.tf
   default = {
     all               = {}
-    default-node-pool = {}
   }
 }
 
@@ -203,7 +197,6 @@ variable "node_pools_taints" {
   # Default is being set in variables_defaults.tf
   default = {
     all               = []
-    default-node-pool = []
   }
 }
 
@@ -214,7 +207,6 @@ variable "node_pools_tags" {
   # Default is being set in variables_defaults.tf
   default = {
     all               = []
-    default-node-pool = []
   }
 }
 
@@ -225,7 +217,6 @@ variable "node_pools_oauth_scopes" {
   # Default is being set in variables_defaults.tf
   default = {
     all               = ["https://www.googleapis.com/auth/cloud-platform"]
-    default-node-pool = []
   }
 }
 
@@ -419,13 +410,13 @@ variable "network_policy_provider" {
 variable "initial_node_count" {
   type        = number
   description = "The number of nodes to create in this cluster's default node pool."
-  default     = 0
+  default     = 1
 }
 
 variable "remove_default_node_pool" {
   type        = bool
   description = "Remove default node pool while setting up the cluster"
-  default     = false
+  default     = true
 }
 
 variable "filestore_csi_driver" {


### PR DESCRIPTION
Changes for removing default node pool. 
Although, there is no code for default module creation, it creates a nodepool with 0 count and deletes when actual nodepool ( user designed ) deployed. 